### PR TITLE
Updated instructions using windeploy.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Various personal howtos : softwares installs, build recipes, etc...
 Feel free to fork/stole/comment etc...
 
 ## Recent
-* [Build pgModeler 0.9.0 for Windows 64-bit on Windows](https://github.com/miniwark/miniwark-howtos/blob/master/build_pgModeler0.9.0_for_Windows_64-bit.md)
+* [Build pgModeler 0.9.3 for Windows 64-bit on Windows](https://github.com/miniwark/miniwark-howtos/blob/master/build_pgModeler0.9.0_for_Windows_64-bit.md)
 
 ## Outdated
 * [Setup Mandriva Directory Server on Ubuntu 12.04](https://github.com/miniwark/miniwark-howtos/blob/master/setup_Mandriva_Directory_Server_on_Ubuntu_12.04.md)

--- a/build_pgModeler0.9.0_for_Windows_64-bit.md
+++ b/build_pgModeler0.9.0_for_Windows_64-bit.md
@@ -58,24 +58,21 @@ When asked, just install all the members.
 
 To install the libraries required to build pgModeler run:
 ```
-> pacman -S mingw-w64-x86_64-qt5 mingw-w64-x86_64-postgresql mingw-w64-x86_64-libxml2
+> pacman -S mingw-w64-x86_64-qt5 mingw-w64-x86_64-qt-installer mingw-w64-x86_64-postgresql mingw-w64-x86_64-libxml2
 ```
-This will install Qt5, PostgreSQL and libxml2 as MSYS2/MinGW libraries.
+This will install Qt5, QT Installer Framework, PostgreSQL and libxml2 as MSYS2/MinGW binaries.
 
 Alternately, you can install them system wide with the windows graphical installers
 from [Qt](https://www1.qt.io/download-open-source/)
 and [PostgreSQL](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads)
-(libxml2 is included in the PostgreSQL installer). 
+(libxml2 is included in the PostgreSQL installer). Don't forget to include the QT Installer Framework.
 
-Both methods works, the first one is just more easy to update thanks to `pacman`.
+Both methods work, the first one is just easier to update thanks to `pacman`.
 
 If you use the graphical installer for postgreSQL, be careful to not install PostgreSQL in the default
 directory (`C:\Program Files\PostgreSQL`) because there is space in `Program Files` and this will break
 the building scripts. Install it directly under `C:\PostgreSQL`. For example, for PostgreSQL 9.6.5,
 install it under `C:\PostgreSQL\9.6`. 
-
-Finally download and install [InnoSetup](http://www.jrsoftware.org/isinfo.php) who will be used to create
-an offline installer for pgModeler (there is not yet a MSYS2 package for InnoSetup).
 
 
 ## Build pgModeler
@@ -87,115 +84,66 @@ Launch the MinGW 64-bit shell from the start menu and get the pgModeler sources 
 ```
 > git clone https://github.com/pgmodeler/pgmodeler.git
 > cd pgmodeler
-> git checkout tags/v0.9.0
+> git checkout tags/v0.9.3
 ```
-We will build the 0.9.0 version of pgModeler. If a new version is available since this How-To,
+We will build the 0.9.3 version of pgModeler. If a new version is available since this How-To,
 you just need to change the tag accordingly. You can also try to build from `git checkout master`
 or `git checkout devel` for more up-to-date releases.
 
 
 ### Setup
 
-If you have installed PostgreSQL and libxml2 with `pacman`, you need to edit the `pgmodeler.pri` file to point
-to the needed libraries like this:
-```
-windows {
-  !defined(PGSQL_LIB, var): PGSQL_LIB = C:/msys64/mingw64/bin/libpq.dll
-  !defined(PGSQL_INC, var): PGSQL_INC = C:/msys64/mingw64/include
-  !defined(XML_INC, var): XML_INC = C:/msys64/mingw64/include/libxml2
-  !defined(XML_LIB, var): XML_LIB = C:/msys64/mingw64/bin/libxml2-2.dll
-  ...
-}
+Since version 0.9.2-alpha1, pgModeler is now configured and built for Windows through the `windeploy.sh`
+script using the QT Installer Framework. While most of the procedure is done automatically, you still 
+have to check for a few parameters to be right.
 
-```
+The script assumes that you installed PostgreSQL and QT through MSYS. If that is not the case,
+edit the script and alter the values of `QT_ROOT`, `PGSQL_ROOT` and `QMAKE_ARGS` (which assumes
+that the PostgreSQL include files and libraries are installed inwide MINGW). And as you will notice,
+you will also have to alter `MINGW_ROOT` if you didn't install MSYS/MINGW in the default locations.
 
-If you have used the graphical installers instead, then the file is probably already correct. 
-It must look like something like:
-```
-windows {
-  !defined(PGSQL_LIB, var): PGSQL_LIB = C:/PostgreSQL/9.6/lib/libpq.dll
-  !defined(PGSQL_INC, var): PGSQL_INC = C:/PostgreSQL/9.6/include
-  !defined(XML_INC, var): XML_INC = C:/PostgreSQL/9.6/include
-  !defined(XML_LIB, var): XML_LIB = C:/PostgreSQL/9.6/bin/libxml2.dll
-  ...
-}
-
-```
 <small>Note: `vim` was installed alongside `git`, so you can use it to edit the files.
 You can also install other editors like `nano` from MSYS2.</small>
 
 
 ### Build
 
-For building the application do the following commands:
+For building the application just send the following command:
 ```
-> qmake pgmodeler.pro
-> make
-> make install
-> cd build
-> windeployqt --compiler-runtime pgmodeler.exe
+> /bin/bash ./windeploy.sh -x64-build
 ```
 
-This will compile the software and create a `/build` directory with half of the necessary file for running pgModeler.
+This will compile the software and create a `/build` directory with the necessary files for running 
+pgModeler, and then a `/dist` directory where you will find the installer. You can hunt for errors
+in the `windeploy.log` file that the script will generate through the process, and another good measure
+is to add the command `set -x` right at the beginning of the script to debug the whole execution, if you
+are still having trouble.
+
+If the script ran just fine, you can skip to the Install section of this HOWTO.
 
 
-### Copy the required DLL files
+### In case there are missing DLL files
 
-The `/build` directory is not yet complete, we need to add manually the DLLs of the libraries than the `windeployqt`
-command have missed. Most of the missing dependencies are related to postreSQL.
+You will find the `pgmodeler.exe` file in the `/build` directory. Try to execute it, and if the application 
+does not come up, complaining instead about missing libraries, try to copy those to the `/build` directory 
+from `/mingw64/bin` and keep trying to run the program and copying the missing libraries util it comes up.
+Most of the missing dependencies are related to postreSQL.
 
-It is required to manually add them to the the `/build` directory. To know the missing libraries, just double-click
-on `/build/pgModeler.exe` and it will give you messages about the missing DLLs.
+This is just in case `windeploy.sh` missed any DLLs, but it shouldn't be.
 
-As the time of this writing, do the following commands inside the `/build` directory to copy the missing DLLs:
+### Manually recreate the Windows installer
+
+To regenerate the installer without restarting the whole `windeploy.sh` process, just run:
+
 ```
-> cp /mingw64/bin/libeay32.dll .
-> cp /mingw64/bin/libfreetype-6.dll .
-> cp /mingw64/bin/libglib-2.0-0.dll .
-> cp /mingw64/bin/libgraphite2.dll .
-> cp /mingw64/bin/libharfbuzz-0.dll .
-> cp /mingw64/bin/libiconv-2.dll .
-> cp /mingw64/bin/libicudt58.dll .
-> cp /mingw64/bin/libicuin58.dll .
-> cp /mingw64/bin/libicuuc58.dll .
-> cp /mingw64/bin/libintl-8.dll .
-> cp /mingw64/bin/liblzma-5.dll .
-> cp /mingw64/bin/libpcre-1.dll .
-> cp /mingw64/bin/libpcre2-16-0.dll .
-> cp /mingw64/bin/libpng16-16.dll .
-> cp /mingw64/bin/libpq.dll .
-> cp /mingw64/bin/libxml2-2.dll .
-> cp /mingw64/bin/libbz2-1.dll .
-> cp /mingw64/bin/Qt5Networkd.dll .
-> cp /mingw64/bin/Qt5PrintSupportd.dll .
-> cp /mingw64/bin/ssleay32.dll .
-> cp /mingw64/bin/zlib1.dll .
-```
-<small>Note than the DLLs names may change since the writing of this tutorial.</small>
-
-
-### Create the Windows installer
-
-By now, you can already run pgModeler directly by double-clicking it inside the `/build` directory,
-but if you want to create an installer, and have nice short-cuts in Windows you nees to create the installer
-with the help of InnoSetup.
-
-First go back inside the `pgmodeler` directory:
-```
-> cd ~/pgmodeler
-```
-and then launch the following command in the minGW 64-bit shell:
-```
-> "/c/Program Files (x86)/Inno Setup 5/ISCC.exe" ./installer/windows/pgmodeler.iss
+> binarycreator -v -c installer/template/config/config.xml -p installer/template/packages dist/pgmodeler-0.9.3-windows64.exe
 ```
 
-Alternately you can also build the package with the graphical Inno Setup Compiler from your start menu.
-You will have to point to the `pgmodeler.iss` file witch will be somewhere like
-`C:\msys64\home\yourusername\pgmodeler\installer\windows\pgmodeler.iss`
+Otherwise, invoking `windeploy.sh` again will force a cleanup and run a rebuild.
 
 
 ## Install
 
-Inno Setup should have create a `pgmodele.exe` file inside  `C:\msys64\home\myusername\pgmodeler`.
+QT Installer Framework should have created a `pgmodeler-0.9.3-windows64.exe` file inside  `/dist`.
 This is the installer executable. Just run it to install PgModeler.
 


### PR DESCRIPTION
windeploy.sh is simpler to use and Inno Setup has been abandoned in favor of QT Installer Framework.